### PR TITLE
CLOUD-1113: Optionally fail action when process run fails

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -19,5 +19,4 @@ jobs:
           workspace-id: ${{ secrets.ROBOCORP_WORKSPACE_ID }}
           process-id: ${{ secrets.ROBOCORP_PROCESS_ID }}
           payload: '{"term":"cute dog picture"}'
-          fail-on-fail: false
           await-complete: true

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -19,4 +19,5 @@ jobs:
           workspace-id: ${{ secrets.ROBOCORP_WORKSPACE_ID }}
           process-id: ${{ secrets.ROBOCORP_PROCESS_ID }}
           payload: '{"term":"cute dog picture"}'
+          fail-on-fail: false
           await-complete: true

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ jobs:
 
 ##### Configuration
 
-| Option         | Value   | Required | Default                                 | Description                                                            |
-| -------------- | ------- | -------- | --------------------------------------- | ---------------------------------------------------------------------- |
-| api-key        | string  | \*       |                                         | Workspace API key with `read_runs` and `trigger_processes` permissions |
-| workspace-id   | string  | \*       |                                         | The target Robocorp Cloud workspace ID                                 |
-| process-id     | string  | \*       |                                         | The target Robocorp Cloud process ID                                   |
-| payload        | string  |          | "{}"                                    | Stringified JSON payload passed to process                             |
-| await-complete | boolean |          | false                                   | Should the action await process run completion                         |
-| fail-on-fail   | boolean |          | true                                    | Fail the GitHub workflow run if Robocorp Cloud process fails           |
-| timeout        | number  |          | 120                                     | Process run await timeout in seconds                                   |
-| api-endpoint   | string  |          | https://api.eu1.robocloud.eu/process-v1 | Robocorp workspace API endpoint                                        |
+| Option             | Value   | Required | Default                                 | Description                                                            |
+| ------------------ | ------- | -------- | --------------------------------------- | ---------------------------------------------------------------------- |
+| api-key            | string  | \*       |                                         | Workspace API key with `read_runs` and `trigger_processes` permissions |
+| workspace-id       | string  | \*       |                                         | The target Robocorp Cloud workspace ID                                 |
+| process-id         | string  | \*       |                                         | The target Robocorp Cloud process ID                                   |
+| payload            | string  |          | "{}"                                    | Stringified JSON payload passed to process                             |
+| await-complete     | boolean |          | false                                   | Should the action await process run completion                         |
+| fail-on-robot-fail | boolean |          | true                                    | Fail the GitHub workflow run if Robocorp Cloud process fails           |
+| timeout            | number  |          | 120                                     | Process run await timeout in seconds                                   |
+| api-endpoint       | string  |          | https://api.eu1.robocloud.eu/process-v1 | Robocorp workspace API endpoint                                        |

--- a/README.md
+++ b/README.md
@@ -33,5 +33,6 @@ jobs:
 | process-id     | string  | \*       |                                         | The target Robocorp Cloud process ID                                   |
 | payload        | string  |          | "{}"                                    | Stringified JSON payload passed to process                             |
 | await-complete | boolean |          | false                                   | Should the action await process run completion                         |
+| fail-on-fail   | boolean |          | true                                    | Fail the GitHub workflow run if Robocorp Cloud process fails           |
 | timeout        | number  |          | 120                                     | Process run await timeout in seconds                                   |
 | api-endpoint   | string  |          | https://api.eu1.robocloud.eu/process-v1 | Robocorp workspace API endpoint                                        |

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: JSON payload for the robot
   await-complete:
     description: Should the action wait for process completion
+  fail-on-fail:
+    description: Fail the GitHub worklfow run if Robocorp process run failed
+    default: true
   timeout:
     description: Max time to wait for the action to complete (in seconds)
     default: '120'

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: JSON payload for the robot
   await-complete:
     description: Should the action wait for process completion
-  fail-on-fail:
+  fail-on-robot-fail:
     description: Fail the GitHub worklfow run if Robocorp process run failed
     default: true
   timeout:

--- a/dist/index.js
+++ b/dist/index.js
@@ -80,8 +80,8 @@ const awaitProcess = (processUrl) => __awaiter(void 0, void 0, void 0, function*
             if (json.state === 'COMPL') {
                 if (json.result === 'ERR') {
                     console.info(`Robot failed with an error`);
-                    const failOnFail = core_1.getInput('fail-on-fail');
-                    return !(failOnFail === 'true' || failOnFail === '1');
+                    const shouldFail = core_1.getInput('fail-on-robot-fail');
+                    return !(shouldFail === 'true' || shouldFail === '1');
                 }
                 console.info('Robot completed succesfully', JSON.stringify(json));
                 return true;

--- a/dist/index.js
+++ b/dist/index.js
@@ -80,7 +80,8 @@ const awaitProcess = (processUrl) => __awaiter(void 0, void 0, void 0, function*
             if (json.state === 'COMPL') {
                 if (json.result === 'ERR') {
                     console.info(`Robot failed with an error`);
-                    return false;
+                    const failOnFail = core_1.getInput('fail-on-fail');
+                    return !(failOnFail === 'true' || failOnFail === '1');
                 }
                 console.info('Robot completed succesfully', JSON.stringify(json));
                 return true;
@@ -111,7 +112,7 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
     try {
         const processUrl = yield triggerProcess();
         const awaitComplete = core_1.getInput('await-complete');
-        if (awaitComplete.length && awaitComplete !== 'false' && awaitComplete !== '0') {
+        if (awaitComplete.length && (awaitComplete === 'true' || awaitComplete === '1')) {
             const response = yield awaitProcess(processUrl);
             if (!response) {
                 core_1.setFailed('Robot failed to execute');

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,9 @@ const awaitProcess = async (processUrl: string): Promise<boolean> => {
       if (json.state === 'COMPL') {
         if (json.result === 'ERR') {
           console.info(`Robot failed with an error`);
-          return false;
+
+          const failOnFail = getInput('fail-on-fail');
+          return !(failOnFail === 'true' || failOnFail === '1');
         }
 
         console.info('Robot completed succesfully', JSON.stringify(json));
@@ -87,7 +89,7 @@ const run = async (): Promise<void> => {
 
     const awaitComplete = getInput('await-complete');
 
-    if (awaitComplete.length && awaitComplete !== 'false' && awaitComplete !== '0') {
+    if (awaitComplete.length && (awaitComplete === 'true' || awaitComplete === '1')) {
       const response = await awaitProcess(processUrl);
 
       if (!response) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,8 +48,8 @@ const awaitProcess = async (processUrl: string): Promise<boolean> => {
         if (json.result === 'ERR') {
           console.info(`Robot failed with an error`);
 
-          const failOnFail = getInput('fail-on-fail');
-          return !(failOnFail === 'true' || failOnFail === '1');
+          const shouldFail = getInput('fail-on-robot-fail');
+          return !(shouldFail === 'true' || shouldFail === '1');
         }
 
         console.info('Robot completed succesfully', JSON.stringify(json));


### PR DESCRIPTION
Only trigger failure when an argument is set. We want to keep the actions backwards compatible.